### PR TITLE
fix: change :crypto.hmac to :crypto.mac

### DIFF
--- a/lib/ex_kucoin/auth.ex
+++ b/lib/ex_kucoin/auth.ex
@@ -11,8 +11,7 @@ defmodule ExKucoin.Auth do
     body = if Enum.empty?(body), do: "", else: Jason.encode!(body)
     data = "#{timestamp}#{method}#{path}#{body}"
 
-    :sha256
-    |> :crypto.hmac(api_secret, data)
+    :crypto.mac(:hmac, :sha256, api_secret, data)
     |> Base.encode64()
   end
 end


### PR DESCRIPTION
:crypto.hmac/{3,4} is deprecated and is removed in Erlang/OTP 24.
:crypto.mac/4 should be instead, but it is available only since Erlang/OTP 22.1.

source: https://elixirforum.com/t/undefinedfunctionerror-function-crypto-hmac-3-is-undefined-or-private/40060/2