### PR TITLE
updated Api.Private for v2 API key auth headers and added usage of th…

### DIFF
--- a/lib/ex_kucoin/api/private.ex
+++ b/lib/ex_kucoin/api/private.ex
@@ -49,13 +49,16 @@ defmodule ExKucoin.Api.Private do
   defp headers(method, path, body, config) do
     timestamp = ExKucoin.Auth.timestamp()
     signed = ExKucoin.Auth.sign(timestamp, method, path, body, config.api_secret)
-
+    passphrase = :crypto.mac(:hmac, :sha256, config.api_secret, config.api_passphrase)
+    |> Base.encode64()
+    
     [
       "Content-Type": "application/json",
       "KC-API-KEY": config.api_key,
       "KC-API-SIGN": signed,
       "KC-API-TIMESTAMP": timestamp,
-      "KC-API-PASSPHRASE": config.api_passphrase
+      "KC-API-PASSPHRASE": passphrase,
+      "KC-API-KEY-VERSION": "2"
     ]
   end
 end

--- a/lib/ex_kucoin/api/private.ex
+++ b/lib/ex_kucoin/api/private.ex
@@ -49,10 +49,7 @@ defmodule ExKucoin.Api.Private do
   defp headers(method, path, body, config) do
     timestamp = ExKucoin.Auth.timestamp()
     signed = ExKucoin.Auth.sign(timestamp, method, path, body, config.api_secret)
-
-    passphrase =
-      :crypto.mac(:hmac, :sha256, config.api_secret, config.api_passphrase)
-      |> Base.encode64()
+    passphrase = ExKucoin.Auth.encrypt(config.api_passphrase, config.api_secret)
 
     [
       "Content-Type": "application/json",

--- a/lib/ex_kucoin/api/private.ex
+++ b/lib/ex_kucoin/api/private.ex
@@ -49,9 +49,11 @@ defmodule ExKucoin.Api.Private do
   defp headers(method, path, body, config) do
     timestamp = ExKucoin.Auth.timestamp()
     signed = ExKucoin.Auth.sign(timestamp, method, path, body, config.api_secret)
-    passphrase = :crypto.mac(:hmac, :sha256, config.api_secret, config.api_passphrase)
-    |> Base.encode64()
-    
+
+    passphrase =
+      :crypto.mac(:hmac, :sha256, config.api_secret, config.api_passphrase)
+      |> Base.encode64()
+
     [
       "Content-Type": "application/json",
       "KC-API-KEY": config.api_key,

--- a/lib/ex_kucoin/auth.ex
+++ b/lib/ex_kucoin/auth.ex
@@ -8,11 +8,13 @@ defmodule ExKucoin.Auth do
 
   @spec sign(String.t(), String.t(), String.t(), map | [map], String.t()) :: String.t()
   def sign(timestamp, method, path, body, api_secret) do
-    body = if Enum.empty?(body) and method in ["GET", "DELETE"] do
-      ""
-    else
-      Jason.encode!(body)
-    end
+    body =
+      if Enum.empty?(body) and method in ["GET", "DELETE"] do
+        ""
+      else
+        Jason.encode!(body)
+      end
+
     data = "#{timestamp}#{method}#{path}#{body}"
 
     :crypto.mac(:hmac, :sha256, api_secret, data)

--- a/lib/ex_kucoin/auth.ex
+++ b/lib/ex_kucoin/auth.ex
@@ -15,9 +15,10 @@ defmodule ExKucoin.Auth do
         Jason.encode!(body)
       end
 
-    data = "#{timestamp}#{method}#{path}#{body}"
-
-    :crypto.mac(:hmac, :sha256, api_secret, data)
-    |> Base.encode64()
+    "#{timestamp}#{method}#{path}#{body}"
+    |> encrypt(api_secret)
   end
+
+  @spec encrypt(String.t(), String.t()) :: String.t()
+  def encrypt(data, secret), do: :crypto.mac(:hmac, :sha256, secret, data) |> Base.encode64()
 end

--- a/lib/ex_kucoin/auth.ex
+++ b/lib/ex_kucoin/auth.ex
@@ -8,7 +8,11 @@ defmodule ExKucoin.Auth do
 
   @spec sign(String.t(), String.t(), String.t(), map | [map], String.t()) :: String.t()
   def sign(timestamp, method, path, body, api_secret) do
-    body = if Enum.empty?(body), do: "", else: Jason.encode!(body)
+    body = if Enum.empty?(body) and method == "GET" do
+      ""
+    else
+      Jason.encode!(body)
+    end
     data = "#{timestamp}#{method}#{path}#{body}"
 
     :crypto.mac(:hmac, :sha256, api_secret, data)

--- a/lib/ex_kucoin/auth.ex
+++ b/lib/ex_kucoin/auth.ex
@@ -8,7 +8,7 @@ defmodule ExKucoin.Auth do
 
   @spec sign(String.t(), String.t(), String.t(), map | [map], String.t()) :: String.t()
   def sign(timestamp, method, path, body, api_secret) do
-    body = if Enum.empty?(body) and method == "GET" do
+    body = if Enum.empty?(body) and method in ["GET", "DELETE"] do
       ""
     else
       Jason.encode!(body)

--- a/lib/ex_kucoin/web_socket.ex
+++ b/lib/ex_kucoin/web_socket.ex
@@ -128,17 +128,19 @@ defmodule ExKucoin.WebSocket do
 
       @spec get_endpoint() :: api_url
       defp get_endpoint() do
-	opts = unquote(opts)
-	maybe_bool = Keyword.get(opts, :private, false)
-	is_private = if is_boolean(maybe_bool), do: maybe_bool, else: false
+        opts = unquote(opts)
+        maybe_bool = Keyword.get(opts, :private, false)
+        is_private = if is_boolean(maybe_bool), do: maybe_bool, else: false
 
-	mod = case is_private do
-		true -> ExKucoin.WebSocket.Private
-		false -> ExKucoin.WebSocket.Public
-	      end
-	
-        {:ok, %{"code" => "200000", "data" => %{"token" => token, "instanceServers" => servers}}} = mod.endpoint()
-	
+        mod =
+          case is_private do
+            true -> ExKucoin.WebSocket.Private
+            false -> ExKucoin.WebSocket.Public
+          end
+
+        {:ok, %{"code" => "200000", "data" => %{"token" => token, "instanceServers" => servers}}} =
+          mod.endpoint()
+
         %{"endpoint" => api_url} = hd(servers)
         "#{api_url}?token=#{token}"
       end

--- a/lib/ex_kucoin/web_socket/private.ex
+++ b/lib/ex_kucoin/web_socket/private.ex
@@ -17,13 +17,13 @@ defmodule ExKucoin.WebSocket.Private do
      "code" => "200000",
      "data" => %{
        "instanceServers" => [
-	 %{
-	   "encrypt" => true,
-	   "endpoint" => "wss://ws-api.kucoin.com/endpoint",
-	   "pingInterval" => 18000,
-	   "pingTimeout" => 10000,
-	   "protocol" => "websocket"
-	 }
+   %{
+     "encrypt" => true,
+     "endpoint" => "wss://ws-api.kucoin.com/endpoint",
+     "pingInterval" => 18000,
+     "pingTimeout" => 10000,
+     "protocol" => "websocket"
+   }
        ],
        "token" => "2neAiuYvAU737TOajb2U3uT8AEZqSWYe0fBD4LoHuXJDSC7gIzJiH4kNTWhCPISWo6nDpAe7aUaafcTuDcaTb9Y9HDQx1qgfCXBoSsKykcRgDIupKTmYlnwZIngtMdMrjqPnP-biofGYc9o00VDGKWT05Kg2glnDJBvJHl5Vs9Y=.Fq059TQcs0a_KI7plBcacA=="
     }

--- a/lib/ex_kucoin/web_socket/private.ex
+++ b/lib/ex_kucoin/web_socket/private.ex
@@ -1,0 +1,35 @@
+defmodule ExKucoin.WebSocket.Private do
+  @moduledoc """
+  Retrieve private WebSocket endpoint information
+
+  [API docs](https://docs.kucoin.com/#apply-connect-token)
+  """
+  import ExKucoin.Api.Private
+
+  @doc """
+  Fetch private WebSocket endpoint info
+
+  # Examples
+
+  iex> ExKucoin.WebSocket.Private.endpoint()
+  {:ok,
+   %{
+     "code" => "200000",
+     "data" => %{
+       "instanceServers" => [
+	 %{
+	   "encrypt" => true,
+	   "endpoint" => "wss://ws-api.kucoin.com/endpoint",
+	   "pingInterval" => 18000,
+	   "pingTimeout" => 10000,
+	   "protocol" => "websocket"
+	 }
+       ],
+       "token" => "2neAiuYvAU737TOajb2U3uT8AEZqSWYe0fBD4LoHuXJDSC7gIzJiH4kNTWhCPISWo6nDpAe7aUaafcTuDcaTb9Y9HDQx1qgfCXBoSsKykcRgDIupKTmYlnwZIngtMdMrjqPnP-biofGYc9o00VDGKWT05Kg2glnDJBvJHl5Vs9Y=.Fq059TQcs0a_KI7plBcacA=="
+    }
+  }}
+  """
+  def endpoint do
+    post("/api/v1/bullet-private")
+  end
+end


### PR DESCRIPTION
This PR allows `ExKucoin.WebSocket`  client's to call the `/api/v1/bullet-private` kucoin endpoint and subscribe to private channels.

Example:

```
defmodule KuWs.Feed do
  require Logger
  use ExKucoin.WebSocket, private: true
   
  ....

  def get_private_channels() do
    [
      "/market/candles:BTC-USDT_1min"
    ]

  def get_private_channels() do
    [
      "/spotMarket/tradeOrders"
    ]
  end
end
```

Default behavior is to use the public endpoint.